### PR TITLE
Bug: Fixed text input auto selection on iOS Safari

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -128,6 +128,12 @@ function isNumeric(n) {
     return !isNaN(parseFloat(n)) && isFinite(n);
 }
 
+function selectInputText(input) {
+	setTimeout(function() {
+		input.setSelectionRange(0, input.value.length);
+	}, 1);
+}
+
 function req(url, fun, params) {
     var http = new XMLHttpRequest();
     http.open(params ? "POST" : "GET", url, true);
@@ -484,11 +490,11 @@ function build_ui_area() {
 	tr.innerHTML = `<td>${make_player_link(game[0])}<td>${make_player_link(game[1])}<td>Bana ${game[6] || "x"}<td><input class="p1" pattern="^[-wW\\d]$" size=2 value=${game[2]}><td><input class="p2" pattern="^[-wW\\d]$" size=2 value=${game[3]}>`;
 
         tr.querySelector('input.p1').onfocus = function () {
-            this.setSelectionRange(0, this.value.length);
+			selectInputText(this)
         };
 
         tr.querySelector('input.p2').onfocus = function () {
-            this.setSelectionRange(0, this.value.length);
+			selectInputText(this)
         };
 
 	tr.querySelector('input.p1').onchange = function () {


### PR DESCRIPTION
A major annoyance is that when trying to enter the score on Mobile Safari, iOS, it was hard to get rid of the default value "-" as text is not selected on focus (as it is on other browsers/devices).

This is kind of a hack, but it solves the issue. t's a known bug in mobile safari:
http://stackoverflow.com/questions/3272089/programmatically-selecting-text-in-an-input-field-on-ios-devices-mobile-safari

On a side note: This file is full of mix between tabs and spaces, and I stuck with tabs because there seems to be no default convention. Should probably be fixed in separate PR/commit