### PR TITLE
Added editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+[*.py]
+indent_style = spaces
+indent_size = 4
+
+[*.{js,html,css}]
+indent_style = spaces
+indent_size = 4


### PR DESCRIPTION
Editorconfig is a useful tool to assign project specific settings
when it comes to basic formatting rules, like tabs vs. spaces

For instance at work i use tabs, at home i use spaces,
using this file, my VIM will read the .editorconfig file
and use whatever is preffered in the current project im working on

eg. Useful for switching quickly between projects at home.

Read more on http://editorconfig.org/